### PR TITLE
Set default language en_US.utf8

### DIFF
--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -5,6 +5,8 @@ FROM centos:${VERSION}
 ENV TZ=Asia/Shanghai
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+ENV LANG=en_US.utf8
+
 RUN yum update -y && yum install -y centos-release-scl epel-release \
   && yum install -y \
     curl \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -8,6 +8,8 @@ ARG VERSION=xenial
 ENV TZ=Asia/Shanghai
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+ENV LANG=en_US.utf8
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
@@ -16,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 \
     libc-dev \
     libreadline-dev \
+    locales-all \
     lsb-core \
     m4 \
     make \


### PR DESCRIPTION
fix #32 , fix #33 

After this patch, insider docker container, `locale` will give following results:

```bash
root@5d09a3fae42e:~# locale
LANG=en_US.utf8
LANGUAGE=
LC_CTYPE="en_US.utf8"
LC_NUMERIC="en_US.utf8"
LC_TIME="en_US.utf8"
LC_COLLATE="en_US.utf8"
LC_MONETARY="en_US.utf8"
LC_MESSAGES="en_US.utf8"
LC_PAPER="en_US.utf8"
LC_NAME="en_US.utf8"
LC_ADDRESS="en_US.utf8"
LC_TELEPHONE="en_US.utf8"
LC_MEASUREMENT="en_US.utf8"
LC_IDENTIFICATION="en_US.utf8"
LC_ALL=
[root@4fc5a275cbc5 ~]# locale -a
aa_DJ
aa_DJ.iso88591
aa_DJ.utf8
aa_ER
aa_ER@saaho
aa_ER.utf8
aa_ER.utf8@saaho
aa_ET
aa_ET.utf8
af_ZA
af_ZA.iso88591
af_ZA.utf8
am_ET
am_ET.utf8
an_ES
an_ES.iso885915
an_ES.utf8
ar_AE
ar_AE.iso88596
...
```