### PR TITLE
Restrore v3.0 third party install 

### DIFF
--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -79,12 +79,14 @@ RUN wget -qO- https://github.com/git/git/archive/v2.25.0.tar.gz | tar zxf - -C .
   && make -j$(nproc) && make install \
   && cd ../ && rm -rf git-2.25.0
 
-# Install nebula third-party 1.0 and 2.0 and 3.3
+# Install nebula third-party 1.0 and 2.0 and 3.0 and 3.3
 RUN git clone https://github.com/vesoft-inc/nebula-third-party.git \
   && cd nebula-third-party \
   && ./install-third-party.sh \
   && git checkout origin/release-3.3 \
   && ./install-third-party.sh \
+  && git checkout origin/v3.0 \
+  && ./install-third-party.sh \  
   && git checkout origin/v2.0 \
   && ./install-third-party.sh \
   && git checkout origin/v1.0 \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -68,11 +68,13 @@ RUN wget -qO- https://github.com/git/git/archive/v2.25.0.tar.gz | tar zxf - -C .
   && make -j$(nproc) && make install \
   && cd ../ && rm -rf git-2.25.0
 
-# Install nebula third-party 1.0 and 2.0 and 3.0
+# Install nebula third-party 1.0 and 2.0 and 3.0 and 3.3
 RUN git clone https://github.com/vesoft-inc/nebula-third-party.git \
     && cd nebula-third-party \
     && ./install-third-party.sh \
     && git checkout origin/release-3.3 \
+    && ./install-third-party.sh \
+    && git checkout origin/v3.0 \
     && ./install-third-party.sh \
     && git checkout origin/v2.0 \
     && ./install-third-party.sh \


### PR DESCRIPTION
Because of third party v3.0 branch has been restore , nebula-dev should be restore install command.